### PR TITLE
add luma schedule CTA and to header

### DIFF
--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -259,6 +259,10 @@ interface NavItem {
 
 const NAV_ITEMS: Array<NavItem> = [
   {
+    label: 'Schedule',
+    href: 'https://lu.ma/event-group/evgrp-MSZlmyEPurQp9zX',
+  },
+  {
     label: 'FAQ',
     href: '#faq',
   },

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -153,7 +153,7 @@ const Home: NextPage<Props> = (props) => {
             </Stack>
           </Stack>
           <Stack spacing="6" align="center">
-            <div>
+            <Box display="flex" flexWrap="wrap" justifyContent="center">
               <Button
                 as="a"
                 colorScheme={'blackAlpha'}
@@ -161,10 +161,25 @@ const Home: NextPage<Props> = (props) => {
                 size="lg"
                 onClick={onRegisterOpen}
                 cursor="pointer"
+                mx="2"
+                my={{ base: '1', md: '0' }}
               >
                 Register to attend
               </Button>
-            </div>
+              <Button
+                as="a"
+                color="black"
+                bgGradient="radial-gradient(98.71% 98.71% at 52.79% 99.41%, #FFC5C0 0%, #FFF1C0 100%, #FFF1C0 100%)"
+                border="2px solid black"
+                size="lg"
+                href="https://lu.ma/event-group/evgrp-MSZlmyEPurQp9zX"
+                cursor="pointer"
+                mx="2"
+                my={{ base: '1', md: '0' }}
+              >
+                See Event Schedule
+              </Button>
+            </Box>
             <Text>
               Want to host an event?{' '}
               <Link

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -177,7 +177,7 @@ const Home: NextPage<Props> = (props) => {
                 mx="2"
                 my={{ base: '1', md: '0' }}
               >
-                See Event Schedule
+                See event schedule
               </Button>
             </Box>
             <Text>


### PR DESCRIPTION
Two changes:
1) Add "Schedule" Luma link to header
2) Add "See Event Schedule" call to action next to "Register to attend".  Followed the same design as the "Register" button in top right for some design consistency and contrast from existing "Register to attend" black button



<img width="1387" alt="Screen Shot 2022-10-17 at 9 37 35 PM" src="https://user-images.githubusercontent.com/16062590/196336727-4288f488-9ec7-4251-a3a0-7745fe60e2dc.png">

<img width="757" alt="Screen Shot 2022-10-17 at 9 37 45 PM" src="https://user-images.githubusercontent.com/16062590/196336724-b2549e66-e11a-41b7-aa3e-8b69e4126e78.png">

