### PR TITLE
update facecard people and add links to /about page

### DIFF
--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -270,4 +270,8 @@ const NAV_ITEMS: Array<NavItem> = [
     label: 'Host event',
     href: '#host',
   },
+  {
+    label: 'Organizers',
+    href: '/about',
+  },
 ];

--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -86,6 +86,14 @@ const faceCardList: FaceCardInfo[] = [
     linkedInHref: '',
   },
   {
+    name: 'Josh Constine',
+    title: 'Venture Partner',
+    company: 'SignalFire',
+    imgSrc: 'https://media-exp1.licdn.com/dms/image/C5603AQGggkXC-oYeiA/profile-displayphoto-shrink_800_800/0/1550706238611?e=1671667200&v=beta&t=LoJdXcITep0_8fijQqTOBmGRQD02pQjfmnKm157WseM',
+    twitterHref: 'https://twitter.com/JoshConstine',
+    linkedInHref: 'https://www.linkedin.com/in/joshconstine/',
+  },
+  {
     name: 'Mel Flores Salman',
     title: 'Event Marketing',
     company: '',
@@ -112,6 +120,15 @@ const faceCardList: FaceCardInfo[] = [
       'https://media-exp1.licdn.com/dms/image/C5603AQGS1vjTEDrnZQ/profile-displayphoto-shrink_800_800/0/1657608430559?e=1670457600&v=beta&t=kWxCDnpEp5N2HmS3_PqCve8jVVHzRqyuneUh-hJSySw',
     twitterHref: '',
     linkedInHref: 'https://www.linkedin.com/in/zuleika-tesei/',
+  },
+  {
+    name: 'Tarlon Khoubyari',
+    title: 'Marketing and Communications Leader',
+    company: '',
+    imgSrc:
+      'https://media-exp1.licdn.com/dms/image/C5603AQFuJy98ny1bow/profile-displayphoto-shrink_800_800/0/1648076692967?e=1671667200&v=beta&t=Mp-dbofDwF4694A-CbMPCCpAjfE2q9SmX89-cmB8bdk',
+    twitterHref: 'https://twitter.com/TarlonKhoubyari',
+    linkedInHref: 'https://www.linkedin.com/in/tarlon-khoubyari/',
   },
 ];
 

--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -138,6 +138,9 @@ const About: NextPage = () => {
       <Heading as="h2" pt={vertPadding}>
         Who Are We?
       </Heading>
+      <Heading as='h5' size='sm' pt={3}>
+        SF Tech Week is organized by a number of VCs, entrepreneurs, and community leaders in the Bay Area.
+      </Heading>
       <SimpleGrid pt={vertPadding} spacing="24px" columns={{ base: 1, md: 4 }}>
         {faceCardList.map((faceCardInfo) => (
           <FaceCard {...faceCardInfo} key={faceCardInfo.name} />

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -71,13 +71,12 @@ const FAQ = [
   },
   {
     title: 'Who is organizing SF Tech Week?',
-    description:
-      'SFTW is organized by a number of VCs, entrepreneurs, and community leaders in the Bay Area.',
+    description: <Box>SFTW is organized by a number of VCs, entrepreneurs, and community leaders in the Bay Area. <Link textDecoration="underline" href="/about">See organizers here</Link>.</Box>,
   },
   {
     title: 'What kind of events should I expect?',
-    description:
-      'Events will range from fireside chats to expert panels to workshops. There will be something for everyone.',
+    description: <Box>Events will range from fireside chats to expert panels to workshops. There will be something for everyone. <Link textDecoration="underline" href="/events">See event schedule here</Link>.</Box>
+    ,
   },
   {
     title: 'I want to host an event, what do I do?',


### PR DESCRIPTION
1) Updated /about page with updated data from [google sheet](https://docs.google.com/spreadsheets/d/119fjHUAspZcdgSQxFikwxOCs7SO244TsekoasQkcZuA/edit#gid=173687412).

2) Added links in the FAQ answers to the /about and /events page.

<img width="500" alt="Screen Shot 2022-10-20 at 6 04 36 PM" src="https://user-images.githubusercontent.com/16062590/197087512-fd5f5a1a-7719-4c1b-9b21-0a4482ea81a9.png">

3) added `Organizers` link to header

4) added subheading to /about page based on existing copy on home #faq section
